### PR TITLE
Decreased SolidBrush creation/destruction

### DIFF
--- a/ConsoleBuffer.sln
+++ b/ConsoleBuffer.sln
@@ -20,14 +20,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D890EB09-11B9-41A8-B9A7-C1D159312A32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D890EB09-11B9-41A8-B9A7-C1D159312A32}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D890EB09-11B9-41A8-B9A7-C1D159312A32}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D890EB09-11B9-41A8-B9A7-C1D159312A32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A16D11B0-4785-434F-8514-ABCC16DDFBFD}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D11953E5-195F-43F4-9109-DE93CED6D016}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D11953E5-195F-43F4-9109-DE93CED6D016}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D11953E5-195F-43F4-9109-DE93CED6D016}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/condo/Screen.cs
+++ b/src/condo/Screen.cs
@@ -45,6 +45,7 @@ namespace condo
         bool cursorInverted;
         private volatile int shouldRedraw;
         private int consoleBufferSize;
+        private SolidBrushCache brushCache = new SolidBrushCache();
 
         private static readonly TimeSpan MaxRedrawFrequency = TimeSpan.FromMilliseconds(10);
         private readonly Stopwatch redrawWatch = new Stopwatch();
@@ -192,7 +193,7 @@ namespace condo
 
         public void SetCellCharacter(int x, int y, bool invert = false)
         {
-            var ch = this.characters[x, y];
+            var ch = this.characters[x,y];
 
             using (var dc = this.GetCell(x, y).RenderOpen())
             {
@@ -208,8 +209,8 @@ namespace condo
                         this.baselineOrigin, new[] { 0.0 }, new[] { new Point(0, 0) }, null, null, null, null, null);
                 }
 
-                var backgroundBrush = new SolidColorBrush(new Color { R = ch.Background.R, G = ch.Background.G, B = ch.Background.B, A = 255 });
-                var foregroundBrush = new SolidColorBrush(new Color { R = ch.Foreground.R, G = ch.Foreground.G, B = ch.Foreground.B, A = 255 });
+                var backgroundBrush = this.brushCache.GetBrush(ch.Background.R, ch.Background.G, ch.Background.B);
+                var foregroundBrush = this.brushCache.GetBrush(ch.Foreground.R, ch.Foreground.G, ch.Foreground.B);
                 dc.DrawRectangle(!invert ? backgroundBrush : foregroundBrush, null, new Rect(new Point(0, 0), new Point(this.cellWidth, this.cellHeight)));
                 dc.DrawGlyphRun(!invert ? foregroundBrush : backgroundBrush, gr);
             }
@@ -217,7 +218,7 @@ namespace condo
 
         public void RenderCharacter(Character c, int x, int y)
         {
-            this.characters[x, y] = c;
+            this.characters[x,y] = c;
         }
 
         private void Redraw()
@@ -231,7 +232,7 @@ namespace condo
             }
         }
 
-        #region IScrollInfo
+#region IScrollInfo
         public bool CanVerticallyScroll { get; set; }
         public bool CanHorizontallyScroll { get; set; }
 
@@ -318,6 +319,6 @@ namespace condo
         {
             throw new NotImplementedException();
         }
-        #endregion
+#endregion
     }
 }

--- a/src/condo/SolidBrushCache.cs
+++ b/src/condo/SolidBrushCache.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.Windows.Media;
+
+namespace condo
+
+{
+    public class SolidBrushCache
+    {
+        Dictionary<uint, SolidColorBrush> cache = new Dictionary<uint, SolidColorBrush>();
+
+        public SolidBrushCache() { }
+
+        public SolidColorBrush GetBrush(byte R, byte G, byte B, byte A = 255)
+        {
+            byte[] bar = { R, B, G, A };
+            uint hash = BitConverter.ToUInt32(bar, 0);
+
+            
+            if (this.cache.TryGetValue(hash, out var br))
+            {
+                return br;
+            }
+
+            br = new SolidColorBrush(new Color { R = R, G = G, B = B, A = 255 });
+
+            this.cache.Add(hash, br);
+
+            return br;
+        }
+    }
+}

--- a/src/condo/condo.csproj
+++ b/src/condo/condo.csproj
@@ -58,6 +58,7 @@
     </ApplicationDefinition>
     <Compile Include="KeyHandler.cs" />
     <Compile Include="Screen.cs" />
+    <Compile Include="SolidBrushCache.cs" />
     <Compile Include="TerminalManager.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
Built cache for SolidBrush creation, saves about 3-4% on render.  This will have to be modified for large palettes (start destroying least used brushes), but this should be good for the 95% case.