### PR TITLE
Make BrushCache use an LRU

### DIFF
--- a/src/ConsoleBuffer/ConsoleBuffer.csproj
+++ b/src/ConsoleBuffer/ConsoleBuffer.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Update="xterm-colors.json">

--- a/src/condo/Screen.cs
+++ b/src/condo/Screen.cs
@@ -198,16 +198,12 @@ namespace condo
             using (var dc = this.GetCell(x, y).RenderOpen())
             {
                 GlyphRun gr;
-                try
+                if (!this.typeface.CharacterToGlyphMap.TryGetValue((char)ch.Glyph, out ushort glyphValue))
                 {
-                    gr = new GlyphRun(this.typeface, 0, false, this.fontSize, (float)this.dpiInfo.PixelsPerDip, new[] { this.typeface.CharacterToGlyphMap[(char)ch.Glyph] },
-                        this.baselineOrigin, new[] { 0.0 }, new[] { new Point(0, 0) }, null, null, null, null, null);
+                    glyphValue = 0;
                 }
-                catch (KeyNotFoundException)
-                {
-                    gr = new GlyphRun(this.typeface, 0, false, this.fontSize, (float)this.dpiInfo.PixelsPerDip, new[] { this.typeface.CharacterToGlyphMap[0] },
-                        this.baselineOrigin, new[] { 0.0 }, new[] { new Point(0, 0) }, null, null, null, null, null);
-                }
+                gr = new GlyphRun(this.typeface, 0, false, this.fontSize, (float)this.dpiInfo.PixelsPerDip, new[] { glyphValue },
+                    this.baselineOrigin, new[] { 0.0 }, new[] { new Point(0, 0) }, null, null, null, null, null);
 
                 var backgroundBrush = this.brushCache.GetBrush(ch.Background.R, ch.Background.G, ch.Background.B);
                 var foregroundBrush = this.brushCache.GetBrush(ch.Foreground.R, ch.Foreground.G, ch.Foreground.B);

--- a/src/condo/SolidBrushCache.cs
+++ b/src/condo/SolidBrushCache.cs
@@ -37,6 +37,7 @@ namespace condo
             }
 
             var brush = new SolidColorBrush(new Color { R = R, G = G, B = B, A = A });
+            brush.Freeze();
             if (this.cache.Count == CacheSize)
             {
                 node = this.lruEntries.Last;

--- a/src/condo/condo.csproj
+++ b/src/condo/condo.csproj
@@ -15,6 +15,8 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/test/ConsoleBufferTests/ConsoleBufferTests.csproj
+++ b/test/ConsoleBufferTests/ConsoleBufferTests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This modifies the BrushCache from @BarryNolte to have it use an LRU. See comments for my decisions on cache size. This also fixes a performance regression from not freezing the SolidColorBrush objects (this appears to be an issue with the objects having a longer lifecycle which is why it did not manifest with the short lived ones).

Related to #5 I think this would complete the desired change.