### PR TITLE
Decrease allocations during parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,4 @@ ASALocalRun/
 
 # Local History for Visual Studio
 .localhistory/
+*.diagsession

--- a/src/ConsoleBuffer/Commands/CursorMove.cs
+++ b/src/ConsoleBuffer/Commands/CursorMove.cs
@@ -22,7 +22,7 @@ namespace ConsoleBuffer.Commands
                 throw new ArgumentOutOfRangeException(nameof(cmd));
             }
             this.Direction = (CursorDirection)(cmd - 'A');
-            this.Count = this.ParameterToNumber(0, defaultValue: 1);
+            this.Count = this.Parameters.GetValue(0, defaultValue: 1);;
         }
     }
 }

--- a/src/ConsoleBuffer/Commands/EraseCharacter.cs
+++ b/src/ConsoleBuffer/Commands/EraseCharacter.cs
@@ -8,7 +8,7 @@ namespace ConsoleBuffer.Commands
 
         public EraseCharacter(string bufferData) : base(bufferData)
         {
-            this.Count = this.ParameterToNumber(0, defaultValue: 1);
+            this.Count = this.Parameters.GetValue(0, defaultValue: 1); 
         }
     }
 }

--- a/src/ConsoleBuffer/Commands/EraseIn.cs
+++ b/src/ConsoleBuffer/Commands/EraseIn.cs
@@ -34,9 +34,10 @@ namespace ConsoleBuffer.Commands
             {
                 this.Direction = Parameter.Before;
             }
-            if (this.Parameters.Count == 1 && uint.TryParse(this.Parameters[0], out var param))
-            {
-                param = Math.Min((uint)Parameter.Unknown, param);
+
+            if (this.Parameters.Count == 1)
+            {   
+                var param = Math.Min((uint)Parameter.Unknown, (uint)this.Parameters.GetValue(0));
                 this.Direction = (Parameter)param;
             }
         }

--- a/src/ConsoleBuffer/Commands/SetCursorPosition.cs
+++ b/src/ConsoleBuffer/Commands/SetCursorPosition.cs
@@ -17,15 +17,15 @@ namespace ConsoleBuffer.Commands
             switch (cmd)
             {
             case 'G':
-                this.PosX = this.ParameterToNumber(0, defaultValue: 1) - 1;
+                this.PosX = this.Parameters.GetValue(0, 1) - 1; 
                 break;
             case 'd':
-                this.PosY = this.ParameterToNumber(0, defaultValue: 1) - 1;
+                this.PosY = this.Parameters.GetValue(0, 1) - 1;
                 break;
             case 'H':
             case 'f':
-                this.PosY = this.ParameterToNumber(0, defaultValue: 1) - 1;
-                this.PosX = this.ParameterToNumber(1, defaultValue: 1) - 1;
+                this.PosY = this.Parameters.GetValue(0, 1) - 1; 
+                this.PosX = this.Parameters.GetValue(1, 1) - 1;
                 break;
             }
         }

--- a/src/ConsoleBuffer/Commands/SetGraphicsRendition.cs
+++ b/src/ConsoleBuffer/Commands/SetGraphicsRendition.cs
@@ -62,7 +62,7 @@ namespace ConsoleBuffer.Commands
             var p = 0;
             while (p < this.Parameters.Count)
             {
-                var pValue = this.ParameterToNumber(p, defaultValue: -1);
+                var pValue = this.Parameters.GetValue(p, -1);
                 switch (pValue)
                 {
                 case 0:
@@ -190,14 +190,14 @@ namespace ConsoleBuffer.Commands
             color = new Character.ColorInfo();
             if (++p < this.Parameters.Count)
             {
-                var subCommand = this.ParameterToNumber(p, defaultValue: -1);
+                var subCommand = this.Parameters.GetValue(p, -1);
                 if (subCommand == 2)
                 {
                     var colorValues = new int[3];
                     for (var i = 0; i < colorValues.Length; ++i) // prime candidate for funrolling of loops
                     {
                         ++p;
-                        colorValues[i] = this.ParameterToNumber(p, defaultValue: -1, maxValue: int.MaxValue);
+                        colorValues[i] = this.Parameters.GetValue(p, -1);
                         if (colorValues[i] < 0 || colorValues[i] > 255)
                         {
                             return false;
@@ -209,7 +209,7 @@ namespace ConsoleBuffer.Commands
                 else if (subCommand == 5)
                 {
                     ++p;
-                    value = this.ParameterToNumber(p, defaultValue: -1, maxValue: int.MaxValue);
+                    value = this.Parameters.GetValue(p, -1);
                     return value > -1 && value < 256;
                 }
             }

--- a/src/ConsoleBuffer/Commands/SetMode.cs
+++ b/src/ConsoleBuffer/Commands/SetMode.cs
@@ -27,12 +27,12 @@ namespace ConsoleBuffer.Commands
 
             if (this.Parameters.Count == 1)
             {
-                switch (this.Parameters[0])
+                switch (this.Parameters.GetValue(0))
                 {
-                case "12":
+                case 12:
                     this.Setting = Parameter.CursorBlink;
                     break;
-                case "25":
+                case 25:
                     this.Setting = Parameter.CursorShow;
                     break;
                 }

--- a/test/ConsoleBufferTests/SequenceParserTests.cs
+++ b/test/ConsoleBufferTests/SequenceParserTests.cs
@@ -1,5 +1,6 @@
 namespace ConsoleBufferTests
 {
+    using System;
     using ConsoleBuffer;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,6 +15,33 @@ namespace ConsoleBufferTests
             {
                 Assert.AreEqual(ParserAppendResult.Render, parser.Append(c));
             }
+        }
+
+        [TestMethod]
+        [DataRow("f")]
+        [DataRow("ba")]
+        [DataRow("12g32")]
+        [DataRow("-y")]
+        [DataRow("-3a")]
+        [DataRow("3a-")]
+        [DataRow("3;f")]
+        [DataRow("f;3")]
+        public void BadCharacters(string data)
+        {
+            var command = $"\x1b[{data}X";
+
+            Assert.ThrowsException<AssertFailedException>(() => { this.EnsureCommandParses(command); });
+            
+        }
+
+        [TestMethod]
+        [DataRow("1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20;21;22;23;24;25;26;27;28;29;30;31;32;33;34")]
+        public void BadParameterList(string data)
+        {
+            var command = $"\x1b[{data}X";
+
+            Assert.ThrowsException<IndexOutOfRangeException>(() => { this.EnsureCommandParses(command); });
+
         }
 
         [TestMethod]


### PR DESCRIPTION
Major perf win not using substring and split while parsing control sequences.

I changed the parsing of control sequences so it doesn't perform any allocations.
Used my colortest script as the subject of my test.

**Before**
Total Allocations: ~6 million
Total Time to Run: ~1:40sec

**After**
Total Allocations: ~2.2 million
Total Time to Run: ~45sec