### PR TITLE
Larger read buffer size

### DIFF
--- a/src/ConsoleBuffer/ConsoleWrapper.cs
+++ b/src/ConsoleBuffer/ConsoleWrapper.cs
@@ -183,7 +183,7 @@ namespace ConsoleBuffer
         {
             using (var ptyOutput = new FileStream(this.readHandle, FileAccess.Read))
             {
-                var input = new byte[2048];
+                var input = new byte[4096];
 
                 while (!this.disposed)
                 {


### PR DESCRIPTION
Increased read buffer size to 4K from 2K, since 4K is a page size.  This decreased the time to read from the console when it's very busy from 5% of total test time, to 3% of total test time.